### PR TITLE
feat(middleware): Call `next` for files that match the exclude path.

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,11 +77,7 @@ module.exports = function(options) {
             if (micromatch.any(req.path.replace(/^\/+|\/+$/g, ''), exclude)) {
                 log('Excluded: %s (%s)', req.path, exclude);
                 res.append('X-Babel-Cache', false);
-                res.sendFile(src, {}, function(err) {
-                    if (err) {
-                        handleError(res, err);
-                    }
-                });
+                next();
                 return;
             }
         }

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -249,12 +249,14 @@ describe('middleware', function() {
 
     describe('excluding files', function() {
         beforeEach(function() {
+            var root = __dirname + '/fixtures';
             this.app = express();
             this.app.use(babelMiddleware({
                 cachePath: 'memory',
-                srcPath: __dirname + '/fixtures',
+                srcPath: root,
                 exclude: ['*syntax*']
             }));
+            this.app.use(express.static(root));
         });
 
         it('returns the original file on request', function(done) {


### PR DESCRIPTION
Allow different/additional processing on files that are on the exclude list.
