### PR TITLE
fixed default value of cachePath

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = function(options) {
     // filename to last known hash map
     var hashMap = {};
 
-    var cache = new Cache(options.cachePath, logger, options);
+    var cache = new Cache(cachePath, logger, options);
 
     var babelOptions = options.babelOptions || { presets: [] };
 


### PR DESCRIPTION
File `index.js` contains correct default value for cachePath (memory), but it is not used in Cache constructor call.
Therefore the cache is constructed with `undefined` path by default, and the app fails with "ReferenceError: cachePath is not defined" error.